### PR TITLE
Localized folder fix

### DIFF
--- a/popcorntime
+++ b/popcorntime
@@ -3,7 +3,7 @@ set -e
 architecture=$(uname -m)
 if [ "$architecture" == "x86_64" ]; then bit="64"; else bit="32"; fi
 DIR=/opt/Popcorn-Time
-DL_DIR=~/Downloads
+DL_DIR=$(xdg-user-dir DOWNLOAD)
 NAME="Popcorn Time"
 COMMENT="Watch Movies and TV Shows instantly!"
 CURRENT_DIR=$DIR
@@ -12,38 +12,38 @@ ICON_PATH=$CURRENT_DIR/src/app/images/icon.png
 DESTINATION_DIR=/home/$(whoami)/.local/share/applications
 DESKTOP_FILE=popcorn-time.desktop
 uninstall(){
-	sudo -p '- [sudo] password: ' rm -fr $DIR 2> /dev/null || true
-	sudo rm /usr/bin/popcorntime 2> /dev/null || true
-	sudo rm /usr/share/icons/hicolor/48x48/apps/popcorntime.png 2> /dev/null || true
-	rm $DESTINATION_DIR/$DESKTOP_FILE 2> /dev/null || true
-	sudo gtk-update-icon-cache -q /usr/share/icons/hicolor
+        sudo -p '- [sudo] password: ' rm -fr $DIR 2> /dev/null || true
+        sudo rm /usr/bin/popcorntime 2> /dev/null || true
+        sudo rm /usr/share/icons/hicolor/48x48/apps/popcorntime.png 2> /dev/null || true
+        rm $DESTINATION_DIR/$DESKTOP_FILE 2> /dev/null || true
+        sudo gtk-update-icon-cache -q /usr/share/icons/hicolor
 }
 case $1 in
-	"")
-		if [ -d $DIR ]; then uninstall; fi
-		echo -e "\\n- Installing..."
-		sudo -p "- [sudo] password: " mkdir -p $DIR
-		URL=$(curl -s "https://popcorntime.app" | grep -ow "Linux $bit\" href.*https://get.popcorntime.app/build/Popcorn-Time.*linux$bit.zip" | sed 's:.*https:https:')
-		wget -qc --timeout=15 --waitretry=0 --tries=3 --retry-connrefused --show-progress "$URL" -O $DL_DIR/popcorn.zip
-		sudo unzip -q ~/Downloads/popcorn.zip -d $DIR
-		#sudo ln -sf $DIR/Popcorn-Time /usr/bin/popcorntime
-	    {
-	        echo -e "[Desktop Entry]\\nVersion=$version\\nType=Application\\nName=$NAME\\nIcon=$ICON_PATH\\nExec=\"$EXECUTABLE\" %U\\nComment=$COMMENT\\nCategories=AudioVideo\\nTerminal=false"
-	    } >> "$DESKTOP_FILE"
-		mv "$DESKTOP_FILE" "$DESTINATION_DIR"
-		if [ ! -e /usr/share/icons/hicolor/48x48/apps/popcorntime.png ]; then
-			sudo cp $CURRENT_DIR/src/app/images/icon.png /usr/share/icons/hicolor/48x48/apps/popcorntime.png
-		fi
-		chmod a+x "$DESTINATION_DIR/$DESKTOP_FILE"
-		gio set "$DESTINATION_DIR/$DESKTOP_FILE" metadata::trusted yes
-		sudo gtk-update-icon-cache -q /usr/share/icons/hicolor
-		echo '- Testing Popcorn Time...' && /opt/Popcorn-Time/Popcorn-Time %U 2> /dev/null
-	    echo -e "- Popcorn Time is installed.\\n- Can't find Popcorn Time icon? Reboot your PC.\\n- Report issues via Github: \"https://github.com/looneytkp/Popcorn-Time\".\\n"; exit;;
-	-u)
-		if [ ! -d $DIR ]; then
-			echo -e "\\n- Popcorn-Time is not installed.\\n- Report issues via Github: \"https://github.com/looneytkp/Popcorn-Time\".\\n"
-		else
-			echo -e "\\n- Uninstall Popcorn Time ?"; uninstall; echo -e "- Popcorn Time uninstalled.\\n"
-		fi;;
+        "")
+                if [ -d $DIR ]; then uninstall; fi
+                echo -e "\\n- Installing..."
+                sudo -p "- [sudo] password: " mkdir -p $DIR
+                URL=$(curl -s "https://popcorntime.app" | grep -ow "Linux $bit\" href.*https://get.popcorntime.app/build/Popcorn-Time.*linux$bit.zip" | sed 's:.*https:https:')
+                wget -qc --timeout=15 --waitretry=0 --tries=3 --retry-connrefused --show-progress "$URL" -O $DL_DIR/popcorn.zip
+                sudo unzip -q $(xdg-user-dir DOWNLOAD)/popcorn.zip -d $DIR
+                #sudo ln -sf $DIR/Popcorn-Time /usr/bin/popcorntime
+            {
+                echo -e "[Desktop Entry]\\nVersion=$version\\nType=Application\\nName=$NAME\\nIcon=$ICON_PATH\\nExec=\"$EXECUTABLE\" %U\\nComment=$COMMENT\\nCategories=AudioVideo\\nTerminal=false"
+            } >> "$DESKTOP_FILE"
+                mv "$DESKTOP_FILE" "$DESTINATION_DIR"
+                if [ ! -e /usr/share/icons/hicolor/48x48/apps/popcorntime.png ]; then
+                        sudo cp $CURRENT_DIR/src/app/images/icon.png /usr/share/icons/hicolor/48x48/apps/popcorntime.png
+                fi
+                chmod a+x "$DESTINATION_DIR/$DESKTOP_FILE"
+                gio set "$DESTINATION_DIR/$DESKTOP_FILE" metadata::trusted yes
+                sudo gtk-update-icon-cache -q /usr/share/icons/hicolor
+                echo '- Testing Popcorn Time...' && /opt/Popcorn-Time/Popcorn-Time %U 2> /dev/null
+            echo -e "- Popcorn Time is installed.\\n- Can't find Popcorn Time icon? Reboot your PC.\\n- Report issues via Github: \"https://github.com/looneytkp/Popcorn-Time\".\\n"; exit;;
+        -u)
+                if [ ! -d $DIR ]; then
+                        echo -e "\\n- Popcorn-Time is not installed.\\n- Report issues via Github: \"https://github.com/looneytkp/Popcorn-Time\".\\n"
+                else
+                        echo -e "\\n- Uninstall Popcorn Time ?"; uninstall; echo -e "- Popcorn Time uninstalled.\\n"
+                fi;;
 esac
 # end of script #


### PR DESCRIPTION
Hi there,

Just a quick issue, pointing out, that localized home folders (Videos, Pictures, Downloads, etc...) do cause a problem with your script.

As I’ve got my system set in French, my local Downloads folder, is called Téléchargements, and cause the script to stop, as it can’t found the Downloads folder.  
So, I’ve used of the xdg-users-dir to be able to found the correct folder.